### PR TITLE
sourceCompatibility 11 -> 17 && 빌드시 Spring 배너 안뜨게 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'com.Travelogue'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+	sourceCompatibility = '17'
 }
 
 configurations {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.main.banner-mode=off


### PR DESCRIPTION
오류 발생으로 인해 sourceCompatibility을 다시 17로 변경하였으며, 빌드시 Spring 배너가 표시되지 않게 수정하였습니다.